### PR TITLE
Save the current color scheme to local storage when switching theme [ User Experience Enhancement ]

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -105,6 +105,8 @@ function clockApp() {
             particles.forEach((particle) => {
                 particle.className = `particle ${this.themes[this.currentTheme].website}`
             })
+            // Save the current color scheme to local storage when switching theme
+            this.saveToLocalStorage()
         },
         createParticles() {
             const container = document.getElementById('particles-container')


### PR DESCRIPTION
## Issue
The website wasn't saving the color scheme to the local storage without saving any notes.

## Solution
Now If I switch to any theme, this will save the color scheme to the local storage